### PR TITLE
Fix setter returning a value

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -143,7 +143,9 @@ of the property.
 */
 export function addSnakeCaseShadowProps (obj) {
   Object.keys(obj).filter(key => !key.startsWith('_') && key !== snakeCase(key)).forEach(key => {
-    Object.defineProperty(obj, snakeCase(key), {get: () => obj[key], set: value => obj[key] = value});
+    Object.defineProperty(obj, snakeCase(key), {get: () => obj[key], set: value => {
+      obj[key] = value;
+    }});
   });
   return obj;
 }


### PR DESCRIPTION
146:84  error  Setter cannot return a value  no-setter-return

Previous:

```javascript
export function addSnakeCaseShadowProps (obj) {
  Object.keys(obj).filter(key => !key.startsWith('_') && key !== snakeCase(key)).forEach(key => {
    Object.defineProperty(obj, snakeCase(key), {get: () => obj[key], set: value => obj[key] = value});
  });
  return obj;
}
```

New:

```javascript
export function addSnakeCaseShadowProps (obj) {
  Object.keys(obj).filter(key => !key.startsWith('_') && key !== snakeCase(key)).forEach(key => {
    Object.defineProperty(obj, snakeCase(key), {get: () => obj[key], set: value => {
      obj[key] = value;
    }});
  });
  return obj;
}
```

Not a big change (only fixes a linter error)
