### PR TITLE
get unit tests running, modhashes aren't really used anymore

### DIFF
--- a/src/objects/Listing.js
+++ b/src/objects/Listing.js
@@ -206,6 +206,7 @@ const Listing = class Listing extends Array {
       }
     }
     cloned._children = children;
+    cloned._more.children = cloned._more.children.slice(options.amount);
     return cloned;
   }
   /**

--- a/src/objects/Listing.js
+++ b/src/objects/Listing.js
@@ -206,7 +206,6 @@ const Listing = class Listing extends Array {
       }
     }
     cloned._children = children;
-    cloned._more.children = cloned._more.children.slice(options.amount);
     return cloned;
   }
   /**

--- a/test/snoowrap.spec.js
+++ b/test/snoowrap.spec.js
@@ -5,7 +5,6 @@ const expect = require('chai').use(require('dirty-chai')).expect;
 const Promise = require('bluebird');
 const _ = require('lodash');
 const moment = require('moment');
-const request = require('request-promise');
 const util = require('util');
 const snoowrap = require('..');
 
@@ -45,24 +44,6 @@ describe('snoowrap', function () {
       this.retries(3);
     }
     r.config({request_delay: 1000});
-
-    if (!isBrowser) {
-      const defaultRequest = request.defaults({
-        headers: {'user-agent': oauthInfo.user_agent},
-        json: true,
-        jar: request.jar(),
-        baseUrl: 'https://www.reddit.com/'
-      });
-
-      const loginResponse = await defaultRequest.post('api/login').form({
-        user: oauthInfo.username,
-        passwd: oauthInfo.password,
-        api_type: 'json'
-      });
-
-      expect(loginResponse.json.errors.length).to.equal(0);
-      cookieAgent = defaultRequest.defaults({headers: {'X-Modhash': loginResponse.json.data.modhash}});
-    }
   });
 
   describe('.constructor', () => {


### PR DESCRIPTION
I was able to run the unit tests on the command line and in the browser. I need to regen my oauth tokens with more permissions and a throwaway account to test how broken they really are. Still it was nice to see a decent number passing.

The code I removed was for getting modhashes when not in a browser environment. They aren't returned from the /api/v1/me endpoint anymore, so it seemed reasonable to remove the code.